### PR TITLE
chg: modify conf.sample to use relative path

### DIFF
--- a/etc/server.conf.sample
+++ b/etc/server.conf.sample
@@ -1,5 +1,5 @@
 [global]
-mmdb_file = /home/adulau/git/mmdb-server/db/GeoOpen-Country.mmdb,/home/adulau/git/mmdb-server/db/GeoOpen-Country-ASN.mmdb
-country_file = /home/adulau/git/mmdb-server/db/country.json
+mmdb_file = ../db/GeoOpen-Country.mmdb,../db/GeoOpen-Country-ASN.mmdb
+country_file = ../db/country.json
 lookup_pubsub = no 
 port = 8000


### PR DESCRIPTION
Thanks for the great tool :) It is very easy to use ^^
For first-time users, I made some minor modifications to the sample conf.

## What Changed
The file path written in server.conf.sample has been changed from an absolute path to a relative path.
When I try the tool with contents of [Installation in README](https://github.com/adulau/mmdb-server#installation) first, then I got the following error:
```
fukusuke@fukusukenoAir mmdb-server % git clone https://github.com/fukusuket/mmdb-server.git
fukusuke@fukusukenoAir mmdb-server % cd mmdb-server
fukusuke@fukusukenoAir mmdb-server % cp ./etc/server.conf.sample ./etc/server.conf
fukusuke@fukusukenoAir mmdb-server % cd ./db; bash update.sh; cd ..
...
fukusuke@fukusukenoAir mmdb-server % cd bin; python3 server.py 
Traceback (most recent call last):
  File "/Users/fukusuke/Scripts/Python/mmdb-server/bin/server.py", line 28, in <module>
    with open(country_file) as j:
FileNotFoundError: [Errno 2] No such file or directory: '/home/adulau/git/mmdb-server/db/country.json'
```
I think First-time users often copy and paste [Installation in README](https://github.com/adulau/mmdb-server#installation)  as is, as described above.
Therefore, I changed it in this PR so that an error does not occur even when the sample.conf is copied and pasted as it is.

I would appreciate it if you could review.
Regards,